### PR TITLE
cmd/go: show warnings about symlinks only for patterns containing ...

### DIFF
--- a/src/cmd/go/internal/modload/search.go
+++ b/src/cmd/go/internal/modload/search.go
@@ -86,7 +86,7 @@ func matchPackages(ctx context.Context, m *search.Match, tags map[string]bool, f
 			}
 
 			if !fi.IsDir() {
-				if fi.Mode()&fs.ModeSymlink != 0 && want {
+				if fi.Mode()&fs.ModeSymlink != 0 && want && m.ContainsWildcard() {
 					if target, err := fsys.Stat(path); err == nil && target.IsDir() {
 						fmt.Fprintf(os.Stderr, "warning: ignoring symlink %s\n", path)
 					}

--- a/src/cmd/go/internal/search/search.go
+++ b/src/cmd/go/internal/search/search.go
@@ -52,6 +52,11 @@ func (m *Match) IsLiteral() bool {
 	return !strings.Contains(m.pattern, "...") && !m.IsMeta()
 }
 
+// ContainsWildcard reports whether the pattern contains any wildcard.
+func (m *Match) ContainsWildcard() bool {
+	return strings.Contains(m.pattern, "...")
+}
+
 // Local reports whether the pattern must be resolved from a specific root or
 // directory, such as a filesystem path or a single module.
 func (m *Match) IsLocal() bool {
@@ -155,7 +160,7 @@ func (m *Match) MatchPackages() {
 			}
 
 			if !fi.IsDir() {
-				if fi.Mode()&fs.ModeSymlink != 0 && want {
+				if fi.Mode()&fs.ModeSymlink != 0 && want && m.ContainsWildcard() {
 					if target, err := fsys.Stat(path); err == nil && target.IsDir() {
 						fmt.Fprintf(os.Stderr, "warning: ignoring symlink %s\n", path)
 					}


### PR DESCRIPTION
Go commands show a warning message any time a pattern is expanded and a
symlink to a directory is encountered. For monorepo with non Go projects
using symlinks underneath, the output of go commands could be spammed by
this warning.

This commit includes the behavior change to only print this warning when
there's a pattern containing ... .

Fixes #35941

==== Above is git commit message ======
 
I'll send this CL thru Gerrit, @cespare do you want to take a look before I send it? 